### PR TITLE
fixed access violation when using unicode strings

### DIFF
--- a/include/boost/application/detail/windows/service_setup.hpp
+++ b/include/boost/application/detail/windows/service_setup.hpp
@@ -385,8 +385,8 @@ namespace boost { namespace application {
          char_type serviceDescription[2048];
 
 #if defined(BOOST_APPLICATION_STD_WSTRING)
-         wcscpy_s(serviceDescription, sizeof(serviceDescription),
-                  service_description_.c_str());
+         wcscpy_s(serviceDescription, sizeof(serviceDescription) / sizeof(serviceDescription[0]),
+             service_description_.c_str());
 #else
          strcpy_s(serviceDescription, sizeof(serviceDescription),
                   service_description_.c_str());


### PR DESCRIPTION
second parameter of wcscpy_s is not the size in bytes, but the number of elements.

```
errno_t wcscpy_s(
   wchar_t *strDestination,
   size_t numberOfElements,
   const wchar_t *strSource 
);
```
