### PR TITLE
updated for latest boost::type_index

### DIFF
--- a/include/boost/application/config.hpp
+++ b/include/boost/application/config.hpp
@@ -71,15 +71,19 @@
 // force selection
 #if defined( BOOST_APPLICATION_FEATURE_NS_SELECT_STD )
 #   define BOOST_APPLICATION_FEATURE_NS_SELECT std
+#   define BOOST_APPLICATION_TYPE_INDEX_SELECT std
 #elif defined( BOOST_APPLICATION_FEATURE_NS_SELECT_BOOST )
 #   define BOOST_APPLICATION_FEATURE_NS_SELECT boost
+#   define BOOST_APPLICATION_TYPE_INDEX_SELECT boost::typeind
 #else // auto detect
 // BOOST_APPLICATION_FEATURE_NS_SELECT is used to select correct ns
 // on class members.
 #   ifndef BOOST_NO_CXX11_SMART_PTR
 #      define BOOST_APPLICATION_FEATURE_NS_SELECT std
+#      define BOOST_APPLICATION_TYPE_INDEX_SELECT std
 #   else
 #      define BOOST_APPLICATION_FEATURE_NS_SELECT boost
+#      define BOOST_APPLICATION_TYPE_INDEX_SELECT boost::typeind
 #   endif
 #endif
 
@@ -88,7 +92,7 @@
 #define BOOST_APPLICATION_FEATURE_SELECT                                       \
    using BOOST_APPLICATION_FEATURE_NS_SELECT::make_shared;                     \
    using BOOST_APPLICATION_FEATURE_NS_SELECT::shared_ptr;                      \
-   using BOOST_APPLICATION_FEATURE_NS_SELECT::type_index;                      \
+   using BOOST_APPLICATION_TYPE_INDEX_SELECT::type_index;                      \
    using BOOST_APPLICATION_FEATURE_NS_SELECT::unordered_map;                   \
    using BOOST_APPLICATION_FEATURE_NS_SELECT::static_pointer_cast;
 

--- a/include/boost/application/detail/csbl.hpp
+++ b/include/boost/application/detail/csbl.hpp
@@ -32,12 +32,12 @@ BOOST_APPLICATION_FEATURE_SELECT
 #if defined( BOOST_APPLICATION_FEATURE_NS_SELECT_STD )
       return typeid(T);
 #elif defined( BOOST_APPLICATION_FEATURE_NS_SELECT_BOOST )
-      return type_id<T>();
+      return boost::typeind::type_id<T>();
 #else // auto detect
 #   ifndef BOOST_NO_CXX11_HDR_TYPEINDEX
       return typeid(T);
 #   else
-      return type_id<T>();
+      return boost::typeind::type_id<T>();
 #   endif
 #endif
 

--- a/include/boost/application/detail/windows/common_application_impl.hpp
+++ b/include/boost/application/detail/windows/common_application_impl.hpp
@@ -28,7 +28,7 @@
 // Note that singularity is in approval process,
 // refer to the above link to know more:
 // http://www.boost.org/community/review_schedule.html
-#include <boost/singularity/singularity.hpp>
+#include <singularity/singularity.hpp>
 
 namespace boost { namespace application {
 

--- a/include/boost/application/detail/windows/server_application_impl.hpp
+++ b/include/boost/application/detail/windows/server_application_impl.hpp
@@ -34,7 +34,7 @@
 // Note that singularity is in approval process,
 // refer to the above link to know more:
 // http://www.boost.org/community/review_schedule.html
-#include <boost/singularity/singularity.hpp>
+#include <singularity/singularity.hpp>
 
 #ifdef BOOST_MSVC
 #  pragma warning(push)


### PR DESCRIPTION
boost::type_index undefined with latest changes.
Updated to reflect this - boost::typeind::type_index should be used.
Also removed <boost/ part from singularity include until it not part of the boost.
Here the example project I've used https://github.com/snikulov/boost.app.cmake for reference.
