### PR TITLE
fixed typo (stoped -> stopped) all over the project

### DIFF
--- a/doc/tutorial.qbk
+++ b/doc/tutorial.qbk
@@ -64,7 +64,7 @@ Here we will use the first version.
 [tutorials2]
 
 [note
-By default the signals '[*SIGINT]', '[*SIGTERM]' and '[*SIGABRT]' will change internal state os aspect '[*status]' of application from '[*application::status::running]' to '[*application::status::stoped]'.
+By default the signals '[*SIGINT]', '[*SIGTERM]' and '[*SIGABRT]' will change internal state os aspect '[*status]' of application from '[*application::status::running]' to '[*application::status::stopped]'.
 
 User can customize the default behaviour, refer to [@../html/boost_application/customization.html#boost_application.customization.customize_signal 'Customize Signals/Handlers']
 ] 

--- a/doc/useaspecthandler.qbk
+++ b/doc/useaspecthandler.qbk
@@ -45,7 +45,7 @@ bool stop()
    {
       // return true to tell to the 'application mode engine' to stop application.
       // This implies:
-      // 1. The 'application mode engine' will set the 'application 'status' aspect to status::stoped;
+      // 1. The 'application mode engine' will set the 'application 'status' aspect to status::stopped;
       // 2. The 'application mode engine' will signalize the 'application 'wait_for_termination_request' aspect to release.
       return true;
    }

--- a/example/new_application_mode/apache_httpd_mode.hpp
+++ b/example/new_application_mode/apache_httpd_mode.hpp
@@ -26,9 +26,9 @@
 
 // Apache APR
 #include <apr_dbd.h>
-#include <mod_dbd.h> 
+#include <mod_dbd.h>
 #include <apr_strings.h>
-#include <apr_hash.h>  
+#include <apr_hash.h>
 
 using namespace boost::application;
 
@@ -110,9 +110,9 @@ public:
    }
 
    template <typename Application, typename RequestRec>
-   apache2_httpd_mod(Application& myapp, RequestRec &rr, 
+   apache2_httpd_mod(Application& myapp, RequestRec &rr,
       context& cxt, boost::system::error_code& ec)
-      : error_(OK) 
+      : error_(OK)
    {
       handle_request(myapp, rr, cxt);
    }
@@ -145,32 +145,32 @@ protected:
          error_ = DECLINED; return;
       }
 
-      if (strcmp(rr.handler, appname->web_app_name_.c_str())) 
+      if (strcmp(rr.handler, appname->web_app_name_.c_str()))
       {
          error_ = DECLINED; return;
       }
 
       // we allow only GET
-      
-      // Add other http verbs 
+
+      // Add other http verbs
       // ...
 
       if(rr.method_number != M_GET)
       {
          error_ = HTTP_METHOD_NOT_ALLOWED; return;
       }
-         
+
       // GET
 
       csbl::shared_ptr<http_get_verb_handler> http_get_verb =
          cxt.find<http_get_verb_handler>();
-      
+
       if(http_get_verb)
       {
-         // apache log 
+         // apache log
          cxt.insert<apache_log>(csbl::make_shared<apache_log>(&rr));
 
-         csbl::shared_ptr<content_type> contenttype = 
+         csbl::shared_ptr<content_type> contenttype =
             cxt.find<content_type>();
 
          if(contenttype)
@@ -189,7 +189,7 @@ protected:
       }
 
       // we need set application_state to stop
-      cxt.find<status>()->state(status::stoped);
+      cxt.find<status>()->state(status::stopped);
 
       // we cant find any handler, generate apache error
       error_ = HTTP_INTERNAL_SERVER_ERROR;

--- a/example/simple_server_application.cpp
+++ b/example/simple_server_application.cpp
@@ -1,14 +1,14 @@
 // -----------------------------------------------------------------------------
-// simple_application.cpp : examples that show how use 
-// Boost.Application to make a simplest interactive (terminal) application 
+// simple_application.cpp : examples that show how use
+// Boost.Application to make a simplest interactive (terminal) application
 //
-// Note 1: The Boost.Application (Aspects v4) and this sample are in 
+// Note 1: The Boost.Application (Aspects v4) and this sample are in
 //         development process.
 // -----------------------------------------------------------------------------
 
 // Copyright 2011-2013 Renato Tegon Forti
 //
-// Distributed under the Boost Software License, Version 1.0. (See accompanying 
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
@@ -20,7 +20,7 @@
 // kill -INT <PID>
 
 // output sample on windows service (log.txt)
-// 
+//
 // Start Log...
 // -----------------------------
 // ---------- Arg List ---------
@@ -54,8 +54,8 @@
 #include <boost/program_options.hpp>
 #include <boost/application.hpp>
 
-// provide setup example for windows service   
-#if defined(BOOST_WINDOWS_API)      
+// provide setup example for windows service
+#if defined(BOOST_WINDOWS_API)
 #   include "setup/windows/setup/service_setup.hpp"
 #endif
 
@@ -65,7 +65,7 @@ using namespace boost;
 // my application code
 
 class myapp
-{   
+{
 public:
 
    myapp(application::context& context)
@@ -79,7 +79,7 @@ public:
 
       // dump args
 
-      std::vector<std::string> arg_vector = 
+      std::vector<std::string> arg_vector =
          context_.find<application::args>()->arg_vector();
 
       my_log_file_ << "-----------------------------" << std::endl;
@@ -87,7 +87,7 @@ public:
       my_log_file_ << "-----------------------------" << std::endl;
 
       // only print args on screen
-      for(std::vector<std::string>::iterator it = arg_vector.begin(); 
+      for(std::vector<std::string>::iterator it = arg_vector.begin();
          it != arg_vector.end(); ++it) {
          my_log_file_ << *it << std::endl;
       }
@@ -96,11 +96,11 @@ public:
 
       // run logic
 
-      boost::shared_ptr<application::status> st =          
+      boost::shared_ptr<application::status> st =
          context_.find<application::status>();
 
       int count = 0;
-      while(st->state() != application::status::stoped)
+      while(st->state() != application::status::stopped)
       {
          boost::this_thread::sleep(boost::posix_time::seconds(1));
 
@@ -114,15 +114,15 @@ public:
    // param
    int operator()()
    {
-      std::string logfile 
+      std::string logfile
          = context_.find<application::path>()->executable_path().string() + "/log.txt";
-      
+
       my_log_file_.open(logfile.c_str());
       my_log_file_ << "Start Log..." << std::endl;
 
       // launch a work thread
       boost::thread thread(&myapp::worker, this);
-      
+
       context_.find<application::wait_for_termination_request>()->wait();
 
       // to run direct
@@ -167,17 +167,17 @@ private:
 
 bool setup(application::context& context)
 {
-   strict_lock<application::aspect_map> guard(context); 
+   strict_lock<application::aspect_map> guard(context);
 
-   boost::shared_ptr<application::args> myargs 
+   boost::shared_ptr<application::args> myargs
       = context.find<application::args>(guard);
 
-   boost::shared_ptr<application::path> mypath 
+   boost::shared_ptr<application::path> mypath
       = context.find<application::path>(guard);
-   
-// provide setup for windows service   
-#if defined(BOOST_WINDOWS_API)      
-#if !defined(__MINGW32__)   
+
+// provide setup for windows service
+#if defined(BOOST_WINDOWS_API)
+#if !defined(__MINGW32__)
 
    // get our executable path name
    boost::filesystem::path executable_path_name = mypath->executable_path_name();
@@ -197,18 +197,18 @@ bool setup(application::context& context)
       po::store(po::parse_command_line(myargs->argc(), myargs->argv(), install), vm);
       boost::system::error_code ec;
 
-      if (vm.count("help")) 
+      if (vm.count("help"))
       {
          std::cout << install << std::cout;
          return true;
       }
 
-      if (vm.count("-i")) 
+      if (vm.count("-i"))
       {
          application::example::install_windows_service(
-         application::setup_arg(vm["name"].as<std::string>()), 
-         application::setup_arg(vm["display"].as<std::string>()), 
-         application::setup_arg(vm["description"].as<std::string>()), 
+         application::setup_arg(vm["name"].as<std::string>()),
+         application::setup_arg(vm["display"].as<std::string>()),
+         application::setup_arg(vm["description"].as<std::string>()),
          application::setup_arg(executable_path_name)).install(ec);
 
          std::cout << ec.message() << std::endl;
@@ -216,27 +216,27 @@ bool setup(application::context& context)
          return true;
       }
 
-      if (vm.count("-u")) 
+      if (vm.count("-u"))
       {
          application::example::uninstall_windows_service(
-            application::setup_arg(vm["name"].as<std::string>()), 
+            application::setup_arg(vm["name"].as<std::string>()),
             application::setup_arg(executable_path_name)).uninstall(ec);
-			   
+
          std::cout << ec.message() << std::endl;
 
          return true;
       }
-      
-#endif      
+
 #endif
-      
+#endif
+
    return false;
 }
 // main
 
 int main(int argc, char *argv[])
-{   
-   
+{
+
    application::context app_context;
    myapp app(app_context);
 
@@ -249,20 +249,20 @@ int main(int argc, char *argv[])
       boost::make_shared<application::args>(argc, argv));
 
    // add termination handler
-  
-   application::handler<>::callback termination_callback 
+
+   application::handler<>::callback termination_callback
       = boost::bind<bool>(&myapp::stop, &app);
 
    app_context.insert<application::termination_handler>(
       boost::make_shared<application::termination_handler_default_behaviour>(termination_callback));
-   
+
    // To  "pause/resume" works, is required to add the 2 handlers.
 
-#if defined(BOOST_WINDOWS_API) 
+#if defined(BOOST_WINDOWS_API)
 
    // windows only : add pause handler
-  
-   application::handler<>::callback pause_callback 
+
+   application::handler<>::callback pause_callback
       = boost::bind<bool>(&myapp::pause, &app);
 
    app_context.insert<application::pause_handler>(
@@ -270,13 +270,13 @@ int main(int argc, char *argv[])
 
    // windows only : add resume handler
 
-   application::handler<>::callback resume_callback 
+   application::handler<>::callback resume_callback
       = boost::bind<bool>(&myapp::resume, &app);
 
    app_context.insert<application::resume_handler>(
       boost::make_shared<application::resume_handler_default_behaviour>(resume_callback));
 
-#endif     
+#endif
 
    // check if we need setup
 
@@ -293,9 +293,9 @@ int main(int argc, char *argv[])
 
    if(ec)
    {
-      std::cout << "[E] " << ec.message() 
+      std::cout << "[E] " << ec.message()
          << " <" << ec.value() << "> " << std::cout;
    }
-   
+
    return result;
 }

--- a/example/simple_server_application_with_auto_handler.cpp
+++ b/example/simple_server_application_with_auto_handler.cpp
@@ -1,14 +1,14 @@
 // -----------------------------------------------------------------------------
-// simple_server_application_with_auto_handler.cpp : examples that show how use 
-// Boost.Application to make a simplest interactive (terminal) application 
+// simple_server_application_with_auto_handler.cpp : examples that show how use
+// Boost.Application to make a simplest interactive (terminal) application
 //
-// Note 1: The Boost.Application (Aspects v4) and this sample are in 
+// Note 1: The Boost.Application (Aspects v4) and this sample are in
 //         development process.
 // -----------------------------------------------------------------------------
 
 // Copyright 2011-2013 Renato Tegon Forti
 //
-// Distributed under the Boost Software License, Version 1.0. (See accompanying 
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
@@ -27,7 +27,7 @@
 // kill -INT <PID>
 
 // output sample on windows service (log.txt)
-// 
+//
 // Start Log...
 // -----------------------------
 // ---------- Arg List ---------
@@ -62,8 +62,8 @@
 #include <boost/application.hpp>
 #include <boost/application/auto_handler.hpp>
 
-// provide setup example for windows service   
-#if defined(BOOST_WINDOWS_API)      
+// provide setup example for windows service
+#if defined(BOOST_WINDOWS_API)
 #   include "setup/windows/setup/service_setup.hpp"
 #endif
 
@@ -73,7 +73,7 @@ using namespace boost;
 // my application code
 
 class myapp
-{   
+{
 public:
 
    myapp(application::context& context)
@@ -87,7 +87,7 @@ public:
 
       // dump args
 
-      std::vector<std::string> arg_vector = 
+      std::vector<std::string> arg_vector =
          context_.find<application::args>()->arg_vector();
 
       my_log_file_ << "-----------------------------" << std::endl;
@@ -95,7 +95,7 @@ public:
       my_log_file_ << "-----------------------------" << std::endl;
 
       // only print args on screen
-      for(std::vector<std::string>::iterator it = arg_vector.begin(); 
+      for(std::vector<std::string>::iterator it = arg_vector.begin();
          it != arg_vector.end(); ++it) {
          my_log_file_ << *it << std::endl;
       }
@@ -104,11 +104,11 @@ public:
 
       // run logic
 
-      boost::shared_ptr<application::status> st =          
+      boost::shared_ptr<application::status> st =
          context_.find<application::status>();
 
       int count = 0;
-      while(st->state() != application::status::stoped)
+      while(st->state() != application::status::stopped)
       {
          boost::this_thread::sleep(boost::posix_time::seconds(1));
 
@@ -122,15 +122,15 @@ public:
    // param
    int operator()()
    {
-      std::string logfile 
+      std::string logfile
          = context_.find<application::path>()->executable_path().string() + "/log.txt";
-      
+
       my_log_file_.open(logfile.c_str());
       my_log_file_ << "Start Log..." << std::endl;
 
       // launch a work thread
       boost::thread thread(&myapp::worker, this);
-      
+
       context_.find<application::wait_for_termination_request>()->wait();
 
       // to run direct
@@ -174,17 +174,17 @@ private:
 
 bool setup(application::context& context)
 {
-   strict_lock<application::aspect_map> guard(context); 
+   strict_lock<application::aspect_map> guard(context);
 
-   boost::shared_ptr<application::args> myargs 
+   boost::shared_ptr<application::args> myargs
       = context.find<application::args>(guard);
 
-   boost::shared_ptr<application::path> mypath 
+   boost::shared_ptr<application::path> mypath
       = context.find<application::path>(guard);
-   
-// provide setup for windows service   
-#if defined(BOOST_WINDOWS_API)      
-#if !defined(__MINGW32__)   
+
+// provide setup for windows service
+#if defined(BOOST_WINDOWS_API)
+#if !defined(__MINGW32__)
 
    // get our executable path name
    boost::filesystem::path executable_path_name = mypath->executable_path_name();
@@ -204,18 +204,18 @@ bool setup(application::context& context)
       po::store(po::parse_command_line(myargs->argc(), myargs->argv(), install), vm);
       boost::system::error_code ec;
 
-      if (vm.count("help")) 
+      if (vm.count("help"))
       {
          std::cout << install << std::cout;
          return true;
       }
 
-      if (vm.count("-i")) 
+      if (vm.count("-i"))
       {
          application::example::install_windows_service(
-         application::setup_arg(vm["name"].as<std::string>()), 
-         application::setup_arg(vm["display"].as<std::string>()), 
-         application::setup_arg(vm["description"].as<std::string>()), 
+         application::setup_arg(vm["name"].as<std::string>()),
+         application::setup_arg(vm["display"].as<std::string>()),
+         application::setup_arg(vm["description"].as<std::string>()),
          application::setup_arg(executable_path_name)).install(ec);
 
          std::cout << ec.message() << std::endl;
@@ -223,28 +223,28 @@ bool setup(application::context& context)
          return true;
       }
 
-      if (vm.count("-u")) 
+      if (vm.count("-u"))
       {
          application::example::uninstall_windows_service(
-            application::setup_arg(vm["name"].as<std::string>()), 
+            application::setup_arg(vm["name"].as<std::string>()),
             application::setup_arg(executable_path_name)).uninstall(ec);
-			   
+
          std::cout << ec.message() << std::endl;
 
          return true;
       }
-      
-#endif      
+
 #endif
-      
+#endif
+
    return false;
 }
 // main
 
 int main(int argc, char *argv[])
-{   
+{
    application::context app_context;
-   
+
    // auto_handler will automatically add termination, pause and resume (windows) handlers
    application::auto_handler<myapp> app(app_context);
    // application::detail::handler_auto_set<myapp> app(app_context);
@@ -255,7 +255,7 @@ int main(int argc, char *argv[])
       boost::make_shared<application::path_default_behaviour>(argc, argv));
 
    app_context.insert<application::args>(
-      boost::make_shared<application::args>(argc, argv));  
+      boost::make_shared<application::args>(argc, argv));
 
    // check if we need setup
 
@@ -272,9 +272,9 @@ int main(int argc, char *argv[])
 
    if(ec)
    {
-      std::cout << "[E] " << ec.message() 
+      std::cout << "[E] " << ec.message()
          << " <" << ec.value() << "> " << std::cout;
    }
-   
+
    return result;
 }

--- a/example/simple_server_application_with_auto_handler_and_global_context.cpp
+++ b/example/simple_server_application_with_auto_handler_and_global_context.cpp
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------------------
-// simple_server_application_with_auto_handler_and_global_context.cpp : 
+// simple_server_application_with_auto_handler_and_global_context.cpp :
 // examples that show how use Boost.Application to make a simplest server
 // application using auto_handler and global_context
 //
@@ -7,7 +7,7 @@
 
 // Copyright 2011-2014 Renato Tegon Forti
 //
-// Distributed under the Boost Software License, Version 1.0. (See accompanying 
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
@@ -19,7 +19,7 @@
 // kill -INT <PID>
 
 // output sample on windows service (log.txt)
-// 
+//
 // Start Log...
 // -----------------------------
 // ---------- Arg List ---------
@@ -53,8 +53,8 @@
 #include <boost/program_options.hpp>
 #include <boost/application.hpp>
 
-// provide setup example for windows service   
-#if defined(BOOST_WINDOWS_API)      
+// provide setup example for windows service
+#if defined(BOOST_WINDOWS_API)
 #   include "setup/windows/setup/service_setup.hpp"
 #endif
 
@@ -68,7 +68,7 @@ inline application::global_context_ptr this_application() {
 }
 
 class myapp
-{   
+{
 public:
 
    void worker()
@@ -77,7 +77,7 @@ public:
 
       // dump args
 
-      const std::vector<std::string> &arg_vector = 
+      const std::vector<std::string> &arg_vector =
          this_application()->find<application::args>()->arg_vector();
 
       my_log_file_ << "-----------------------------" << std::endl;
@@ -85,7 +85,7 @@ public:
       my_log_file_ << "-----------------------------" << std::endl;
 
       // only print args on screen
-      for(std::vector<std::string>::const_iterator it = arg_vector.begin(); 
+      for(std::vector<std::string>::const_iterator it = arg_vector.begin();
          it != arg_vector.end(); ++it) {
          my_log_file_ << *it << std::endl;
       }
@@ -94,11 +94,11 @@ public:
 
       // run logic
 
-      boost::shared_ptr<application::status> st =          
+      boost::shared_ptr<application::status> st =
          this_application()->find<application::status>();
 
       int count = 0;
-      while(st->state() != application::status::stoped)
+      while(st->state() != application::status::stopped)
       {
          boost::this_thread::sleep(boost::posix_time::seconds(1));
 
@@ -112,15 +112,15 @@ public:
    // param
    int operator()()
    {
-      std::string logfile 
+      std::string logfile
          = this_application()->find<application::path>()->executable_path().string() + "/log.txt";
-      
+
       my_log_file_.open(logfile.c_str());
       my_log_file_ << "Start Log..." << std::endl;
 
       // launch a work thread
       boost::thread thread(&myapp::worker, this);
-      
+
       this_application()->find<application::wait_for_termination_request>()->wait();
 
       // to run direct
@@ -163,17 +163,17 @@ private:
 
 bool setup(application::context& context)
 {
-   strict_lock<application::aspect_map> guard(context); 
+   strict_lock<application::aspect_map> guard(context);
 
-   boost::shared_ptr<application::args> myargs 
+   boost::shared_ptr<application::args> myargs
       = context.find<application::args>(guard);
 
-   boost::shared_ptr<application::path> mypath 
+   boost::shared_ptr<application::path> mypath
       = context.find<application::path>(guard);
-   
-// provide setup for windows service   
-#if defined(BOOST_WINDOWS_API)      
-#if !defined(__MINGW32__)   
+
+// provide setup for windows service
+#if defined(BOOST_WINDOWS_API)
+#if !defined(__MINGW32__)
 
    // get our executable path name
    boost::filesystem::path executable_path_name = mypath->executable_path_name();
@@ -193,18 +193,18 @@ bool setup(application::context& context)
       po::store(po::parse_command_line(myargs->argc(), myargs->argv(), install), vm);
       boost::system::error_code ec;
 
-      if (vm.count("help")) 
+      if (vm.count("help"))
       {
          std::cout << install << std::cout;
          return true;
       }
 
-      if (vm.count("-i")) 
+      if (vm.count("-i"))
       {
          application::example::install_windows_service(
-         application::setup_arg(vm["name"].as<std::string>()), 
-         application::setup_arg(vm["display"].as<std::string>()), 
-         application::setup_arg(vm["description"].as<std::string>()), 
+         application::setup_arg(vm["name"].as<std::string>()),
+         application::setup_arg(vm["display"].as<std::string>()),
+         application::setup_arg(vm["description"].as<std::string>()),
          application::setup_arg(executable_path_name)).install(ec);
 
          std::cout << ec.message() << std::endl;
@@ -212,28 +212,28 @@ bool setup(application::context& context)
          return true;
       }
 
-      if (vm.count("-u")) 
+      if (vm.count("-u"))
       {
          application::example::uninstall_windows_service(
-            application::setup_arg(vm["name"].as<std::string>()), 
+            application::setup_arg(vm["name"].as<std::string>()),
             application::setup_arg(executable_path_name)).uninstall(ec);
-			   
+
          std::cout << ec.message() << std::endl;
 
          return true;
       }
-      
-#endif      
+
 #endif
-      
+#endif
+
    return false;
 }
 // main
 
 int main(int argc, char *argv[])
-{   
+{
    application::global_context_ptr ctx = application::global_context::create();
-   
+
    // auto_handler will automatically add termination, pause and resume (windows) handlers
    application::auto_handler<myapp> app(ctx);
    // application::detail::handler_auto_set<myapp> app(app_context);
@@ -244,7 +244,7 @@ int main(int argc, char *argv[])
       boost::make_shared<application::path_default_behaviour>(argc, argv));
 
    this_application()->insert<application::args>(
-      boost::make_shared<application::args>(argc, argv));  
+      boost::make_shared<application::args>(argc, argv));
 
    // check if we need setup
 
@@ -262,10 +262,10 @@ int main(int argc, char *argv[])
 
    if(ec)
    {
-      std::cout << "[E] " << ec.message() 
+      std::cout << "[E] " << ec.message()
          << " <" << ec.value() << "> " << std::cout;
    }
-   
+
    application::global_context::destroy();
 
    return result;

--- a/example/termination_handler.cpp
+++ b/example/termination_handler.cpp
@@ -1,14 +1,14 @@
 // -----------------------------------------------------------------------------
-// limit_single_instance_callback.cpp : examples that show how use 
-// Boost.Application to make a simplest interactive (terminal) application 
+// limit_single_instance_callback.cpp : examples that show how use
+// Boost.Application to make a simplest interactive (terminal) application
 //
-// Note 1: The Boost.Application (Aspects v4) and this sample are in 
+// Note 1: The Boost.Application (Aspects v4) and this sample are in
 //         development process.
 // -----------------------------------------------------------------------------
 
 // Copyright 2011-2013 Renato Tegon Forti
 //
-// Distributed under the Boost Software License, Version 1.0. (See accompanying 
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
@@ -54,14 +54,14 @@ public:
    int operator()()
    {
       std::cout << "operator()" << std::endl;
-	  
+
 	  // using [state]
 
       /*
-      std::shared_ptr<status> state = 
+      std::shared_ptr<status> state =
          context.get_aspect<status>();
 
-      while(state->state() != status::stoped)
+      while(state->state() != status::stopped)
       {
          boost::this_thread::sleep(boost::posix_time::seconds(2));
          std::cout << "running" << std::endl;
@@ -72,7 +72,7 @@ public:
 
       // launch a work thread
       boost::thread thread(boost::bind(&myapp::work_thread, this));
-	  
+
       context_.find<wait_for_termination_request>()->wait();
 
       return 0;
@@ -105,11 +105,11 @@ private:
 // main
 
 int main(int argc, char *argv[])
-{      
+{
    context app_context;
    myapp app(app_context);
 
-   handler<>::callback stop 
+   handler<>::callback stop
       = boost::bind<bool>(&myapp::stop, &app);
 
    app_context.insert<termination_handler>(

--- a/example/termination_handler_with_global_context.cpp
+++ b/example/termination_handler_with_global_context.cpp
@@ -1,14 +1,14 @@
 // -----------------------------------------------------------------------------
-// limit_single_instance_callback.cpp : examples that show how use 
-// Boost.Application to make a simplest interactive (terminal) application 
+// limit_single_instance_callback.cpp : examples that show how use
+// Boost.Application to make a simplest interactive (terminal) application
 //
-// Note 1: The Boost.Application (Aspects v4) and this sample are in 
+// Note 1: The Boost.Application (Aspects v4) and this sample are in
 //         development process.
 // -----------------------------------------------------------------------------
 
 // Copyright 2011-2013 Renato Tegon Forti
 //
-// Distributed under the Boost Software License, Version 1.0. (See accompanying 
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
@@ -57,14 +57,14 @@ public:
    int operator()()
    {
       std::cout << "operator()" << std::endl;
-	  
+
 	  // using [state]
 
       /*
-      std::shared_ptr<status> state = 
+      std::shared_ptr<status> state =
          context.get_aspect<status>();
 
-      while(state->state() != status::stoped)
+      while(state->state() != status::stopped)
       {
          boost::this_thread::sleep(boost::posix_time::seconds(2));
          std::cout << "running" << std::endl;
@@ -75,7 +75,7 @@ public:
 
       // launch a work thread
       boost::thread thread(boost::bind(&myapp::work_thread, this));
-	  
+
       this_application()->find<application::wait_for_termination_request>()->wait();
 
       return 0;
@@ -104,9 +104,9 @@ public:
 // main
 
 int main(int argc, char *argv[])
-{   
-   myapp app; 
-   
+{
+   myapp app;
+
    application::global_context_ptr ctx = application::global_context::create();
 
    application::handler<>::callback callback

--- a/example/tutorial/myfunctor_stage2.hpp
+++ b/example/tutorial/myfunctor_stage2.hpp
@@ -2,11 +2,11 @@
 
 // Copyright 2011-2013 Renato Tegon Forti
 //
-// Distributed under the Boost Software License, Version 1.0. (See accompanying 
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
-// This file is part of tutorial, refer to 'last stage' to see a code that 
+// This file is part of tutorial, refer to 'last stage' to see a code that
 // can be compiled.
 //
 
@@ -30,26 +30,26 @@ public:
    }
 
    int operator()()
-   { 
+   {
       /*<< Retrieves 'status' aspect from your context >>*/
-      boost::shared_ptr<application::status> st =          
+      boost::shared_ptr<application::status> st =
          context_.find<application::status>();
 
       /*<< Check 'aspect' status 'state' >>*/
-      while(st->state() != application::status::stoped)
-      { 
+      while(st->state() != application::status::stopped)
+      {
 	     /*<< Your application loop body >>*/
          boost::this_thread::sleep(boost::posix_time::seconds(1));
          // your application logic here!
       }
-	  
+
       return 0;
    }
 
    // check in next stage
    bool stop()
    {
-      return true; 
+      return true;
    }
 
 private:

--- a/include/boost/application/aspects/status.hpp
+++ b/include/boost/application/aspects/status.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace application {
     * Indicates the current state of application,
     * 3 ways are possible:
     *
-    * - application_stoped
+    * - application_stopped
     * - application_running
     * - application_paused (used only on server appliation on windows side)
     *
@@ -40,7 +40,7 @@ namespace boost { namespace application {
    public:
       // application current state
       enum application_state {
-         stoped = 0,
+         stopped = 0,
          running,
          paused // Windows Service
       };

--- a/include/boost/application/common_application.hpp
+++ b/include/boost/application/common_application.hpp
@@ -56,8 +56,8 @@ namespace boost { namespace application {
    public:
 
       /*!
-       * Retrieves a id that identify application run mode. 
-       *  
+       * Retrieves a id that identify application run mode.
+       *
        */
       static int mode()
       {
@@ -101,7 +101,7 @@ namespace boost { namespace application {
 
          if(!impl_->get_context().find<status>())
              impl_->get_context().insert<status>(
-               csbl::make_shared<status>(status::running)); 
+               csbl::make_shared<status>(status::running));
       }
 
       /*!
@@ -119,7 +119,7 @@ namespace boost { namespace application {
        */
       virtual ~common()
       {
-         impl_->get_context().find<status>()->state(status::stoped);
+         impl_->get_context().find<status>()->state(status::stopped);
       }
 
    private:

--- a/include/boost/application/detail/windows/server_application_impl.hpp
+++ b/include/boost/application/detail/windows/server_application_impl.hpp
@@ -59,7 +59,7 @@ namespace boost { namespace application {
       typedef CharType char_type;
       typedef std::basic_string<char_type> string_type;
 
-      server_application_impl_(const mainop &main, signal_binder &sb, 
+      server_application_impl_(const mainop &main, signal_binder &sb,
          application::context &context, boost::system::error_code& ec)
          : application_impl(context)
          , main_(main)
@@ -120,7 +120,7 @@ namespace boost { namespace application {
       //
 
       bool stop(void)
-      {  
+      {
          csbl::shared_ptr<termination_handler> th =
                context_.find<termination_handler>();
 
@@ -142,7 +142,7 @@ namespace boost { namespace application {
       }
 
       bool pause(void)
-      {    
+      {
          csbl::shared_ptr<pause_handler> ph =
             context_.find<pause_handler>();
 
@@ -164,7 +164,7 @@ namespace boost { namespace application {
       }
 
       bool resume(void)
-      {      
+      {
         csbl::shared_ptr<resume_handler> rh =
            context_.find<resume_handler>();
 
@@ -192,7 +192,7 @@ namespace boost { namespace application {
       // Handle SCM signals
       void service_handler(DWORD dwOpcode)
       {
-         csbl::shared_ptr<status> st = 
+         csbl::shared_ptr<status> st =
             context_.find<status>();
 
          switch (dwOpcode)
@@ -203,7 +203,7 @@ namespace boost { namespace application {
                   // don't accept, returns the service
                   // could not accept control messages
                   return;
-                  
+
                request_terminate(0);
             }
             break;
@@ -211,7 +211,7 @@ namespace boost { namespace application {
             {
                stop();
                request_terminate(0);
-            }            
+            }
             case SERVICE_CONTROL_PAUSE:
             {
                if(!pause())
@@ -354,15 +354,15 @@ namespace boost { namespace application {
          {
          	 error = terminate_code_;
          }
-         
+
       	 stop();
-         
-         csbl::shared_ptr<status> st = 
-            context_.find<status>();       	 
+
+         csbl::shared_ptr<status> st =
+            context_.find<status>();
          csbl::shared_ptr<wait_for_termination_request> tr =
             context_.find<wait_for_termination_request>();
-       	 
-         if(st) st->state(status::stoped);
+
+         if(st) st->state(status::stopped);
          if(tr) tr->proceed();
 
          launch_thread_->join();
@@ -418,15 +418,15 @@ namespace boost { namespace application {
          launch_thread_ = new boost::thread(
             boost::bind(&server_application_impl_::work_thread, this, dw_argc, lpsz_argv));
 
-         HANDLE hevent[2];		 
+         HANDLE hevent[2];
 
          hevent[0] = launch_thread_->native_handle();
          if(hevent[0] == NULL)
          {
             send_status_to_scm(SERVICE_STOPPED, 0, 0, -1);
-            return;		 
+            return;
          }
-		 
+
          // The service is now running.
          // Notify SCM of progress
          if (!send_status_to_scm(SERVICE_RUNNING, 0, 0))
@@ -434,12 +434,12 @@ namespace boost { namespace application {
             terminate(GetLastError());
             return;
          }
-		 
+
          hevent[1] = terminate_event_;
 
          // Wait for stop signal, and then terminate
          WaitForMultipleObjects(2,hevent,FALSE,INFINITE);
-         
+
          if (!send_status_to_scm(SERVICE_STOP_PENDING, 1, 5000))
          {
             terminate(GetLastError());
@@ -453,7 +453,7 @@ namespace boost { namespace application {
       {
          context_.exchange<application::args>(
             csbl::make_shared<application::args>(argc, argv));
-         
+
          result_code_ = main_();
       }
 
@@ -476,7 +476,7 @@ namespace boost { namespace application {
       // Event used to hold ServiceMain from completing
       HANDLE terminate_event_;
       DWORD terminate_code_;
-	  
+
       // Status of service
       SERVICE_STATUS service_status_;
 

--- a/include/boost/application/server_application.hpp
+++ b/include/boost/application/server_application.hpp
@@ -46,13 +46,13 @@ namespace boost { namespace application {
     * template param on launch free function.
     *
     */
-   class server 
+   class server
    {
    public:
 
       /*!
-       * Retrieves a id that identify application run mode. 
-       *  
+       * Retrieves a id that identify application run mode.
+       *
        */
       static int mode()
       {
@@ -114,7 +114,7 @@ namespace boost { namespace application {
        */
       virtual ~server()
       {
-         impl_->get_context().find<status>()->state(status::stoped);
+         impl_->get_context().find<status>()->state(status::stopped);
       }
 
    private:

--- a/include/boost/application/signal_binder.hpp
+++ b/include/boost/application/signal_binder.hpp
@@ -51,7 +51,7 @@ namespace boost { namespace application {
    public:
       explicit signal_binder(context &cxt)
          : signals_(io_service_)
-         , io_service_thread_(0) 
+         , io_service_thread_(0)
          , context_(cxt)
       {
          signals_.async_wait(
@@ -62,7 +62,7 @@ namespace boost { namespace application {
 
       explicit signal_binder(global_context_ptr cxt)
          : signals_(io_service_)
-         , io_service_thread_(0) 
+         , io_service_thread_(0)
          , context_(*cxt.get())
       {
          signals_.async_wait(
@@ -231,7 +231,7 @@ namespace boost { namespace application {
       {
          if (ec)
             return;
-        
+
          if(handler_map_[signal_number].first.is_valid())
          {
             handler<>::callback* cb = 0;
@@ -259,10 +259,10 @@ namespace boost { namespace application {
       asio::io_service io_service_;
       asio::signal_set signals_;
 
-      boost::thread *io_service_thread_; 
+      boost::thread *io_service_thread_;
 
    protected:
-      
+
       // for signal_manager access
       application::context &context_;
 
@@ -341,7 +341,7 @@ namespace boost { namespace application {
       virtual bool termination_signal_handler(void)
       {
          // we need set application_state to stop
-         context_.find<status>()->state(status::stoped);
+         context_.find<status>()->state(status::stopped);
 
          // and signalize wait_for_termination_request
          context_.find<wait_for_termination_request>()->proceed();


### PR DESCRIPTION
Fixed typo in status name (stoped->stopped) all across the project.
