### PR TITLE
fix compile-error 'ambigous call' after change in boost.bind in boost/master

### DIFF
--- a/example/application_mode_select.cpp
+++ b/example/application_mode_select.cpp
@@ -85,7 +85,7 @@ int main(int argc, char** argv)
    // add termination handler
 
    application::handler<>::callback termination_callback 
-      = boost::bind<bool>(&my_application_functor_class::stop, &app);
+      = boost::bind(&my_application_functor_class::stop, &app);
 
    app_context.insert<application::termination_handler>(
       boost::make_shared<

--- a/example/limit_single_instance_callback.cpp
+++ b/example/limit_single_instance_callback.cpp
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
    // way 1
    /*
    application::handler<bool>::callback cb 
-      = boost::bind<bool>(&myapp::instace_aready_running, &app);
+      = boost::bind(&myapp::instace_aready_running, &app);
 
    app_context.insert<application::limit_single_instance>(
       boost::make_shared<application::limit_single_instance_default_behaviour>(appuuid, cb));

--- a/example/limit_single_instance_callback_with_global_context.cpp
+++ b/example/limit_single_instance_callback_with_global_context.cpp
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
    // way 1
    /*
    handler<>::callback cb 
-      = boost::bind<bool>(&myapp::instace_aready_running, &app);
+      = boost::bind(&myapp::instace_aready_running, &app);
    
    // use aspects
 

--- a/example/my_own_termination_handler.cpp
+++ b/example/my_own_termination_handler.cpp
@@ -82,7 +82,7 @@ public:
       : signal_manager(context)
    {
       handler<>::callback cb
-         = boost::bind<bool>(&my_signal_manager::stop, this);
+         = boost::bind(&my_signal_manager::stop, this);
 
       // define my own signal / handler
 #if defined( BOOST_WINDOWS_API )

--- a/example/new_application_mode/apache_httpd.cpp
+++ b/example/new_application_mode/apache_httpd.cpp
@@ -80,7 +80,7 @@ extern "C" int myhandle(request_rec *r)
       boost::make_shared<web_app_name>("boostapp"));
 
    application::handler<std::string>::callback my_http_get_verb
-      = boost::bind<std::string>(
+      = boost::bind(
          &my_apache2_httpd_content_generator_mod::get, &app);
 
    app_context.insert<http_get_verb_handler>(

--- a/example/selfpipe/selfpipe.cpp
+++ b/example/selfpipe/selfpipe.cpp
@@ -139,10 +139,10 @@ public:
       : application::signal_manager(cxt)
    {
       application::handler<>::parameter_callback callback1
-         = boost::bind<bool>(&signal_usr2::signal_usr1_handler, this);
+         = boost::bind(&signal_usr2::signal_usr1_handler, this);
 
       application::handler<>::parameter_callback callback2
-         = boost::bind<bool>(&signal_usr2::signal_usr2_handler, this);
+         = boost::bind(&signal_usr2::signal_usr2_handler, this);
 
       /*<< Define signal bind >>*/ 
       bind(SIGUSR1, callback1); 

--- a/example/simple_server_application.cpp
+++ b/example/simple_server_application.cpp
@@ -248,7 +248,7 @@ int main(int argc, char *argv[])
    // add termination handler
 
    application::handler<>::callback termination_callback
-      = boost::bind<bool>(&myapp::stop, &app);
+      = boost::bind(&myapp::stop, &app);
 
    app_context.insert<application::termination_handler>(
       boost::make_shared<application::termination_handler_default_behaviour>(termination_callback));
@@ -260,7 +260,7 @@ int main(int argc, char *argv[])
    // windows only : add pause handler
 
    application::handler<>::callback pause_callback
-      = boost::bind<bool>(&myapp::pause, &app);
+      = boost::bind(&myapp::pause, &app);
 
    app_context.insert<application::pause_handler>(
       boost::make_shared<application::pause_handler_default_behaviour>(pause_callback));
@@ -268,7 +268,7 @@ int main(int argc, char *argv[])
    // windows only : add resume handler
 
    application::handler<>::callback resume_callback
-      = boost::bind<bool>(&myapp::resume, &app);
+      = boost::bind(&myapp::resume, &app);
 
    app_context.insert<application::resume_handler>(
       boost::make_shared<application::resume_handler_default_behaviour>(resume_callback));

--- a/example/termination_handler.cpp
+++ b/example/termination_handler.cpp
@@ -110,7 +110,7 @@ int main(int argc, char *argv[])
    myapp app(app_context);
 
    handler<>::callback stop
-      = boost::bind<bool>(&myapp::stop, &app);
+      = boost::bind(&myapp::stop, &app);
 
    app_context.insert<termination_handler>(
       boost::make_shared<termination_handler_default_behaviour>(stop));

--- a/example/termination_handler_with_global_context.cpp
+++ b/example/termination_handler_with_global_context.cpp
@@ -110,7 +110,7 @@ int main(int argc, char *argv[])
    application::global_context_ptr ctx = application::global_context::create();
 
    application::handler<>::callback callback
-      = boost::bind<bool>(&myapp::stop, &app);
+      = boost::bind(&myapp::stop, &app);
 
    this_application()->insert<application::termination_handler>(
       boost::make_shared<application::termination_handler_default_behaviour>(callback));

--- a/example/work_queue/work_queue.cpp
+++ b/example/work_queue/work_queue.cpp
@@ -127,9 +127,9 @@ public:
       task_count_ = 0;
 
       //our tasks
-      add_task(gaussian_blur<3>( boost::bind<void>( &myapp::add_result, this, _1 ))); 
-      add_task(gaussian_blur<6>( boost::bind<void>( &myapp::add_result, this, _1 ))); 
-      add_task(gaussian_blur<9>( boost::bind<void>( &myapp::add_result, this, _1 ))); 
+      add_task(gaussian_blur<3>( boost::bind( &myapp::add_result, this, _1 ))); 
+      add_task(gaussian_blur<6>( boost::bind( &myapp::add_result, this, _1 ))); 
+      add_task(gaussian_blur<9>( boost::bind( &myapp::add_result, this, _1 ))); 
      
       context_.find<application::wait_for_termination_request>()->wait();
 
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
    myapp app(app_context);
    
    application::handler<>::callback cb 
-      = boost::bind<bool>(&myapp::stop, &app);
+      = boost::bind(&myapp::stop, &app);
 
    app_context.insert<application::termination_handler>(
       make_shared<application::termination_handler_default_behaviour>(cb));

--- a/include/boost/application/auto_handler.hpp
+++ b/include/boost/application/auto_handler.hpp
@@ -384,7 +384,7 @@ int main()
    // add limit_single_instance handler
 
    application::handler<bool>::parameter_context_callback callback 
-      = boost::bind<bool>(&myapp::instace_aready_running, &app, _1);
+      = boost::bind(&myapp::instace_aready_running, &app, _1);
 
    app_context.insert<application::limit_single_instance>(
       csbl::make_shared<application::limit_single_instance_default_behaviour>(appuuid, callback));
@@ -392,7 +392,7 @@ int main()
    // add termination handler
   
    application::handler<>::parameter_callback termination_callback 
-      = boost::bind<bool>(&myapp::stop, &app, _1);
+      = boost::bind(&myapp::stop, &app, _1);
 
    app_context.insert<application::termination_handler>(
       csbl::make_shared<application::termination_handler_default_behaviour>(termination_callback));
@@ -460,13 +460,13 @@ int main()
    boost::uuids::uuid appuuid = gen("{9F66E4AD-ECA5-475D-8784-4BAA329EF9F2}");
 
     handler<>::global_context_callback limit_single_instance_callback 
-      = boost::bind<bool>(&myapp::instace_aready_running, &app);
+      = boost::bind(&myapp::instace_aready_running, &app);
 
    this_application()->insert<limit_single_instance>(
       csbl::make_shared<limit_single_instance_default_behaviour>(appuuid, limit_single_instance_callback));
 
    handler<>::global_context_callback termination_callback 
-      = boost::bind<bool>(&myapp::stop, &app);
+      = boost::bind(&myapp::stop, &app);
 
    this_application()->insert<termination_handler>(
       csbl::make_shared<termination_handler_default_behaviour>(termination_callback));

--- a/include/boost/application/common_application.hpp
+++ b/include/boost/application/common_application.hpp
@@ -90,7 +90,7 @@ namespace boost { namespace application {
          application::context &context,
          boost::system::error_code& ec)
          : impl_(new common_application_impl(
-                 boost::bind<int>(&Application::operator(), &myapp), sm,
+                 boost::bind(&Application::operator(), &myapp), sm,
                  context, ec))
       {
          if(ec) return;

--- a/include/boost/application/handler.hpp
+++ b/include/boost/application/handler.hpp
@@ -148,7 +148,7 @@ namespace boost { namespace application {
       static boost::function< HandlerReturnType (void) > 
          make_callback(App& app, Handler h)
       {
-         return boost::bind< HandlerReturnType >(h, &app);
+         return boost::bind(h, &app);
       }
 
    private:

--- a/include/boost/application/server_application.hpp
+++ b/include/boost/application/server_application.hpp
@@ -109,7 +109,7 @@ namespace boost { namespace application {
          // need be created after run_mode, status
 
          impl_.reset(new server_application_impl(
-            boost::bind<int>( &Application::operator(), &myapp), sm,
+            boost::bind( &Application::operator(), &myapp), sm,
             context, ec));
       }
 

--- a/include/boost/application/signal_binder.hpp
+++ b/include/boost/application/signal_binder.hpp
@@ -325,7 +325,7 @@ namespace boost { namespace application {
          if(th)
          {
             handler<>::callback cb
-               = boost::bind<bool>(
+               = boost::bind(
                &signal_manager::termination_signal_handler, this);
 
             bind(SIGINT,  th->get_handler(), cb, ec);

--- a/test/ensure_single_instance_test.cpp
+++ b/test/ensure_single_instance_test.cpp
@@ -80,7 +80,7 @@ int test_main(int argc, char** argv)
       boost::uuids::uuid appuuid = gen("{8F66E4AD-ECA5-475D-8784-4BAA329EF9F2}");
 
       application::handler<>::callback cb 
-         = boost::bind<bool>(&myapp2::instace_aready_running_false, &app);
+         = boost::bind(&myapp2::instace_aready_running_false, &app);
 
       cxt.insert<application::limit_single_instance>(
          boost::make_shared<application::limit_single_instance_default_behaviour>(appuuid, cb));
@@ -100,7 +100,7 @@ int test_main(int argc, char** argv)
       boost::uuids::uuid appuuid = gen("{7F66E4AD-ECA5-475D-8784-4BAA329EF9F2}");
 
       application::handler<>::callback cb 
-         = boost::bind<bool>(&myapp2::instace_aready_running_true, &app);
+         = boost::bind(&myapp2::instace_aready_running_true, &app);
 
       cxt.insert<application::limit_single_instance>(
          boost::make_shared<application::limit_single_instance_default_behaviour>(appuuid, cb));
@@ -121,7 +121,7 @@ int test_main(int argc, char** argv)
       application::global_context::create();
 
       application::handler<>::callback cb 
-         = boost::bind<bool>(&myapp::instace_aready_running_false, &app);
+         = boost::bind(&myapp::instace_aready_running_false, &app);
 
       this_application()->insert<application::limit_single_instance>(
          boost::make_shared<application::limit_single_instance_default_behaviour>(appuuid, cb));
@@ -144,7 +144,7 @@ int test_main(int argc, char** argv)
       application::global_context::create();
 
       application::handler<>::callback cb 
-         = boost::bind<bool>(&myapp::instace_aready_running_true, &app);
+         = boost::bind(&myapp::instace_aready_running_true, &app);
 
       this_application()->insert<application::limit_single_instance>(
          boost::make_shared<application::limit_single_instance_default_behaviour>(appuuid, cb));

--- a/test/handler_test.cpp
+++ b/test/handler_test.cpp
@@ -35,7 +35,7 @@ int test_main(int argc, char** argv)
    }
 
    {
-      application::handler<>::callback cb = boost::bind<bool>(
+      application::handler<>::callback cb = boost::bind(
          &handler_test::handler, &app_handler_test);
 
       application::handler<> h(cb);
@@ -47,7 +47,7 @@ int test_main(int argc, char** argv)
    }
 
    {
-      application::handler<>::callback cb = boost::bind<bool>(
+      application::handler<>::callback cb = boost::bind(
          &handler_test::handler, &app_handler_test);
 
       application::handler<> h;

--- a/test/launch_test.cpp
+++ b/test/launch_test.cpp
@@ -48,7 +48,7 @@ public:
       : signal_manager(context)
    {
       application::handler<>::callback cb
-         = boost::bind<bool>(&my_signal_manager::stop, this);
+         = boost::bind(&my_signal_manager::stop, this);
 
       bind(SIGINT,  cb);
    }

--- a/test/signal_binder_test.cpp
+++ b/test/signal_binder_test.cpp
@@ -53,7 +53,7 @@ int test_main(int argc, char** argv)
 
    app_signal_binder.start();
 
-   application::handler<>::callback cb = boost::bind<bool>(
+   application::handler<>::callback cb = boost::bind(
                &handler_test::signal_handler1, &app_handler_test);
 
    boost::system::error_code ec;


### PR DESCRIPTION
After a change with boost.bind the compilation and testing of application failed because of calls to boost.bind.
This should fix this issue.