### PR TITLE
ADD ERROR MESSAGE IF WIN SDK VERSION IS LESS VISTA

### DIFF
--- a/include/boost/application/detail/windows/path_impl.hpp
+++ b/include/boost/application/detail/windows/path_impl.hpp
@@ -14,6 +14,10 @@
 #include <cstdlib>
 #include <shlobj.h>
 
+#if NTDDI_VERSION < NTDDI_VISTA
+#error at least the windows vista feature level of the windows sdk is required, e.g. include https://gist.github.com/BurningEnlightenment/05eef0ba2b569d5e2828 at the beginning of your prefix header
+#endif
+
 #ifdef BOOST_HAS_PRAGMA_ONCE
 # pragma once
 #endif


### PR DESCRIPTION
This little change will issue a descriptive error if no appropriate windows sdk version was selected which should prevent confusion from symbols not being declared as happend in #40.