### PR TITLE
fixed crash with std::thread

### DIFF
--- a/include/boost/application/signal_binder.hpp
+++ b/include/boost/application/signal_binder.hpp
@@ -71,9 +71,9 @@ namespace boost { namespace application {
       virtual ~signal_binder() {
          if(io_service_thread_) {
             io_service_.stop();
-#           ifndef BOOST_APPLICATION_USE_CXX11_HDR_THREAD
-            if (io_service_thread_->joinable()) io_service_thread_->join(); // todo: this fail on std::thread, need check.
-#           endif
+            if (io_service_thread_->joinable()) {
+               io_service_thread_->join();
+            }
          }
       }
 
@@ -324,11 +324,11 @@ namespace boost { namespace application {
       {
          // we need set application_state to stop
          context_.find<status>()->state(status::stopped);
-         
+
          // remove process lock
-         csbl::shared_ptr<limit_single_instance> si 
+         csbl::shared_ptr<limit_single_instance> si
             = context_.find<limit_single_instance>();
-            
+
          if(si)
             si->release(true);
 


### PR DESCRIPTION
When BOOST_APPLICATION_FEATURE_NS_SELECT_BOOST is not defined boost::application crashed on Linux/Windows.

To fix this I remove conditional which blocks join() of io_service_thread_.