### PR TITLE
FIX INCLUDE ORDER OF WINDOWS SDK HEADERS

### DIFF
--- a/include/boost/application/detail/windows/path_impl.hpp
+++ b/include/boost/application/detail/windows/path_impl.hpp
@@ -12,14 +12,14 @@
 #include <boost/filesystem/path.hpp>
 
 #include <cstdlib>
-#include <shlobj.h>
 
 #include <boost/detail/winapi/config.hpp>
 #if BOOST_USE_WINAPI_VERSION < BOOST_WINAPI_VERSION_VISTA
 #error Boost.Application requires at least the windows vista feature level of the windows sdk.
 #endif
-
 #include <boost/detail/winapi/dll.hpp>
+
+#include <shlobj.h>
 
 #ifdef BOOST_HAS_PRAGMA_ONCE
 # pragma once


### PR DESCRIPTION
Include boost/detail/winapi/config.hpp before shlobj.h otherwise
BOOST_USE_WINAPI_VERSION won't have any effect.

This was an oversight in #49. I'm sorry for the inconvenience.