### PR TITLE
Bugfix for the simple_server_application example

### DIFF
--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -120,10 +120,9 @@ exe limit_single_instance
     : limit_single_instance.cpp
     ;
 
-# TODO, fix 2 compile errors
-#exe simple_server_application
-#    : simple_server_application.cpp
-#    ;
+exe simple_server_application
+    : simple_server_application.cpp
+    ;
 
 # auto_handler
 

--- a/example/simple_server_application.cpp
+++ b/example/simple_server_application.cpp
@@ -200,7 +200,7 @@ bool setup(application::context& context)
 
       if (vm.count("help"))
       {
-         std::cout << install << std::cout;
+         std::cout << install << std::endl;
          return true;
       }
 
@@ -292,7 +292,7 @@ int main(int argc, char *argv[])
    if(ec)
    {
       std::cout << "[E] " << ec.message()
-         << " <" << ec.value() << "> " << std::cout;
+         << " <" << ec.value() << "> " << std::endl;
    }
 
    return result;


### PR DESCRIPTION
Fixes two typos which caused compiler errors. Furthermore it reincludes the example in the boost build system.