### PR TITLE
Making travis happy again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,65 @@
 # subject to the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
-# Copyright Antony Polukhin 2014. 
+# Copyright Antony Polukhin 2014-2015.
+
+#
+# See https://svn.boost.org/trac/boost/wiki/TravisCoverals for description of this file
+# and how it can be used with Boost libraries.
+#
+# File revision #5
+
+sudo: required
+dist: trusty
+language: cpp
+compiler:
+    - gcc
+#    - clang
 
 os:
     - linux
 
 env:
-    - CXX_STANDARD=c++98
-    - CXX_STANDARD=c++0x
+    global:
+        # Autodetect Boost branch by using the following code: - BRANCH_TO_TEST=$TRAVIS_BRANCH
+        # or just directly specify it
+        - BRANCH_TO_TEST=$TRAVIS_BRANCH
+
+        # Files, which coverage results must be ignored (files from other projects).
+        # Example: - IGNORE_COVERAGE='*/boost/progress.hpp */filesystem/src/*'
+        - IGNORE_COVERAGE='*/thread/src/* */filesystem/src/*'
+
+        # Explicitly remove the following library from Boost. This may be usefull, if you're for example running Travis
+        # from `Boost.DLL` repo, while Boost already has `dll`.
+        #
+        # By default is eaual to - BOOST_REMOVE=$(basename $TRAVIS_BUILD_DIR)
+        # This will force to use local repo content, instead of the Boost's default.
+        - BOOST_REMOVE=$(basename $TRAVIS_BUILD_DIR)
+
+    matrix:
+        - CXX_STANDARD=c++98
+        - CXX_STANDARD=c++11
+
+###############################################################################################################
+# From this point and below code is same for all the Boost libs
+###############################################################################################################
+
+
+# Installing additional tools
+addons:
+  apt:
+    packages:
+    - valgrind
+    - python-yaml
+    - lcov
 
 before_install:
-    # Set this to the name of your Boost library
-    # Autodetect library name by using the following code: - PROJECT_TO_TEST=`git rev-parse --show-toplevel`
+    # Set this to the name of the library
     - PROJECT_TO_TEST=application
-    # Autodetect branch
-    - BRANCH_TO_TEST=$TRAVIS_BRANCH
     - BOOST_BRANCH_TO_TEST=master
-
-    # From this point and below code is same for all the Boost libs
     # Cloning Boost libraries (fast nondeep cloning)
-    - PROJECT_DIR=`pwd`
     - BOOST=$HOME/boost-local
+    - echo "Testing $PROJECT_TO_TEST, to remove $BOOST/libs/$BOOST_REMOVE, testing branch $BRANCH_TO_TEST"
     - git init $BOOST
     - cd $BOOST
     - git remote add --no-tags -t $BOOST_BRANCH_TO_TEST origin https://github.com/boostorg/boost.git
@@ -36,42 +74,38 @@ before_install:
     - git submodule foreach "git reset --quiet --hard; git clean -fxd"
     - git reset --hard; git clean -fxd
     - git status
-    - rm -rf $BOOST/libs/$PROJECT_TO_TEST
-    - mv $PROJECT_DIR/../Boost.Application/ $BOOST/libs/$PROJECT_TO_TEST
-    - PROJECT_DIR=$BOOST/libs/$PROJECT_TO_TEST
+    - rm -rf $BOOST/libs/$BOOST_REMOVE
+    - mv $TRAVIS_BUILD_DIR $BOOST/libs/$PROJECT_TO_TEST
+    - TRAVIS_BUILD_DIR=$BOOST/libs/$PROJECT_TO_TEST
     - ./bootstrap.sh
     - ./b2 headers
-
-script:
-    - if [ "$CCFLAGS" != "" ]; then FLAGS="cxxflags=\"$CCFLAGS\" linkflags=\"$LINKFLAGS\""; else FLAGS=""; fi
     - cd $BOOST/libs/$PROJECT_TO_TEST/test/
     # remove my env specific files
     - rm ../Jamroot.jam ../boost-build.jam
+
+script:
     # `--coverage` flags required to generate coverage info for Coveralls
-    - ../../../b2 cxxflags="--coverage -std=$CXX_STANDARD" linkflags="--coverage" link=shared
+    - ../../../b2 testing.launcher=valgrind address-model=64 architecture=x86 toolset=$CC cxxflags="--coverage -DBOOST_TRAVISCI_BUILD -std=$CXX_STANDARD" linkflags="--coverage"
 
 after_success:
     # Copying Coveralls data to a separate folder
-    - mkdir -p $PROJECT_DIR/coverals
-    - find ../../../bin.v2/ -name "*.gcda" -exec cp "{}" $PROJECT_DIR/coverals/ \;
-    - find ../../../bin.v2/ -name "*.gcno" -exec cp "{}" $PROJECT_DIR/coverals/ \;
+    - mkdir -p $TRAVIS_BUILD_DIR/coverals
+    - find ../../../bin.v2/ -name "*.gcda" -exec cp "{}" $TRAVIS_BUILD_DIR/coverals/ \;
+    - find ../../../bin.v2/ -name "*.gcno" -exec cp "{}" $TRAVIS_BUILD_DIR/coverals/ \;
 
-    # Preparing Coveralls data by
-    # ... installing the tools
-    - sudo apt-get install -qq python-yaml lcov
-    # ... changind data format to a readable one
-    - lcov --directory $PROJECT_DIR/coverals --base-directory ./ --capture --output-file $PROJECT_DIR/coverals/coverage.info
+    # Preparing Coveralls data by changind data format to a readable one
+    - lcov --directory $TRAVIS_BUILD_DIR/coverals --base-directory ./ --capture --output-file $TRAVIS_BUILD_DIR/coverals/coverage.info
 
     # ... erasing /test/ /example/ folder data
     - cd $BOOST
-    - lcov --remove $PROJECT_DIR/coverals/coverage.info "/usr*" "*/$PROJECT_TO_TEST/test/*" "*/$PROJECT_TO_TEST/tests/*" "*/$PROJECT_TO_TEST/examples/*" "*/$PROJECT_TO_TEST/example/*" -o $PROJECT_DIR/coverals/coverage.info
+    - lcov --remove $TRAVIS_BUILD_DIR/coverals/coverage.info "/usr*" "*/$PROJECT_TO_TEST/test/*" $IGNORE_COVERAGE "*/$PROJECT_TO_TEST/tests/*" "*/$PROJECT_TO_TEST/examples/*" "*/$PROJECT_TO_TEST/example/*" -o $TRAVIS_BUILD_DIR/coverals/coverage.info
 
     # ... erasing data that is not related to this project directly
     - OTHER_LIBS=`grep "submodule .*" .gitmodules | sed 's/\[submodule\ "\(.*\)"\]/"\*\/boost\/\1\.hpp" "\*\/boost\/\1\/\*"/g'| sed "/\"\*\/boost\/$PROJECT_TO_TEST\/\*\"/d" | sed ':a;N;$!ba;s/\n/ /g'`
     - echo $OTHER_LIBS
-    - eval "lcov --remove $PROJECT_DIR/coverals/coverage.info $OTHER_LIBS -o $PROJECT_DIR/coverals/coverage.info"
+    - eval "lcov --remove $TRAVIS_BUILD_DIR/coverals/coverage.info $OTHER_LIBS -o $TRAVIS_BUILD_DIR/coverals/coverage.info"
 
     # Sending data to Coveralls
-    - cd $PROJECT_DIR
+    - cd $TRAVIS_BUILD_DIR
     - gem install coveralls-lcov
     - coveralls-lcov coverals/coverage.info

--- a/example/selfpipe/selfpipe.cpp
+++ b/example/selfpipe/selfpipe.cpp
@@ -133,12 +133,12 @@ public:
 
    /*<< Customize SIGNALS bind >>*/
    signal_usr2(application::global_context_ptr cxt)
-      : application::signal_manager(cxt)
+      : application::signal_manager(*cxt)
    {
-      application::handler<>::parameter_callback callback1
+      application::handler<>::callback callback1
          = boost::bind(&signal_usr2::signal_usr1_handler, this);
 
-      application::handler<>::parameter_callback callback2
+      application::handler<>::callback callback2
          = boost::bind(&signal_usr2::signal_usr2_handler, this);
 
       /*<< Define signal bind >>*/ 

--- a/example/tutorial/myfunctor_stage4.hpp
+++ b/example/tutorial/myfunctor_stage4.hpp
@@ -13,6 +13,7 @@
 #define BOOST_APPLICATION_FEATURE_NS_SELECT_BOOST
 
 #include <iostream>
+#include <fstream>
 #include <boost/application.hpp>
 
 using namespace boost;


### PR DESCRIPTION
**DO NOT MERGE YET**

So as implied by the headline, I'm currently working toward a green "build|passed" travis sticker.

I updated the travis configuration file, so that Ubuntu 14.04 LTS and GCC 4.8 will be used which in turn means that the C++0x (or better C++11) build no longer fails because of Boost.Thread.
Furthermore I fixed the selfpipe example (#52) and the fourth tutorial (#53).

Unfortunately the Travis GCC 4.8 C++11 build of the latter fails (see the build log). I located the problem in `application/auto_handler.hpp` where the `base_selector` of the `auto_handler` class seems to incorrectly pick `handler_auto_set_u` instead of `handler_auto_set_c`. Which of course can't find a standard constructor for `myapp`. Please note that `MSVC19` and `GCC4.8` with `-std=c++03` didn't reproduce the misbehaviour... Any thoughts?