### PR TITLE
CALLS windows_scm CTOR PASSING ERROR CODE

### DIFF
--- a/example/setup/windows/setup/service_setup.hpp
+++ b/example/setup/windows/setup/service_setup.hpp
@@ -245,7 +245,12 @@ namespace boost { namespace application { namespace example {
          }
 
          // Open the SCM on this machine.
-         windows_scm scm(SC_MANAGER_CONNECT);
+         windows_scm scm(SC_MANAGER_CONNECT , ec);
+
+         if(ec)
+         {
+             return;
+         }
 
          // Open this service for DELETE access
          SC_HANDLE hservice = OpenService(scm.get(), service_name_.c_str(), DELETE);
@@ -355,7 +360,12 @@ namespace boost { namespace application { namespace example {
             return;
          }
 
-         windows_scm scm(SC_MANAGER_CREATE_SERVICE);
+         windows_scm scm(SC_MANAGER_CREATE_SERVICE, ec);
+
+         if(ec)
+         {
+             return;
+         }
 
          std::basic_string<char_type> pathname = service_path_name_;
          // Append the switch that causes the process to run as a service.


### PR DESCRIPTION
In both install_service and uninstall_service methods constructs the
windows_scm object passing an error code parameter to be filled in case of
error - as these methods also have such a paremeter to be set in case of
error.

Cherry picked from master 26e959b