### PR TITLE
fixed #47

### DIFF
--- a/include/boost/application/signal_binder.hpp
+++ b/include/boost/application/signal_binder.hpp
@@ -202,7 +202,7 @@ namespace boost { namespace application {
 
       void signal_handler(const boost::system::error_code& ec,
          int signal_number) {
-         csbl::thread thread(&signal_binder::spawn, this, ec, signal_number);
+         spawn(ec, signal_number);
 
          // triggers again
          signals_.async_wait(


### PR DESCRIPTION
Fix for #47 - when std::thread goes out of scope terminate will be invoked.

Use case - press Ctrl+C in console app - crash handler will be called.