### PR TITLE
Boost compatability with versions >= 1.73.0

### DIFF
--- a/include/boost/application.hpp
+++ b/include/boost/application.hpp
@@ -12,6 +12,7 @@
 
 // config
 #include <boost/config.hpp>
+#include <boost/noncopyable.hpp>
 #include <boost/application/config.hpp>
 // application
 #include <boost/application/version.hpp>

--- a/include/boost/application/config.hpp
+++ b/include/boost/application/config.hpp
@@ -67,7 +67,7 @@
 #   include <boost/make_shared.hpp>
 #   include <boost/unordered_map.hpp>
 #   include <boost/thread/thread.hpp>
-#   include <boost/bind.hpp>
+#   include <boost/bind/bind.hpp>
 #   include <boost/function.hpp>
 #   include <boost/type_index.hpp>
 #else // auto detect
@@ -98,7 +98,7 @@
 #      include <functional>
 #      define BOOST_APPLICATION_USE_CXX11_HDR_FUNCTIONAL
 #   else
-#      include <boost/bind.hpp>
+#      include <boost/bind/bind.hpp>
 #      include <boost/function.hpp>
 #   endif
 #   ifndef BOOST_NO_CXX11_HDR_TYPEINDEX

--- a/include/boost/application/detail/windows/path_impl.hpp
+++ b/include/boost/application/detail/windows/path_impl.hpp
@@ -13,11 +13,11 @@
 
 #include <cstdlib>
 
-#include <boost/detail/winapi/config.hpp>
+#include <boost/winapi/config.hpp>
 #if BOOST_USE_WINAPI_VERSION < BOOST_WINAPI_VERSION_VISTA
 #error Boost.Application requires at least the windows vista feature level of the windows sdk.
 #endif
-#include <boost/detail/winapi/dll.hpp>
+#include <boost/winapi/dll.hpp>
 
 #include <shlobj.h>
 
@@ -37,16 +37,16 @@ namespace boost { namespace application { namespace detail {
             // A handle to the loaded module whose path is being requested.
             // If this parameter is NULL, GetModuleFileName retrieves the path of the
             // executable file of the current process.
-            boost::detail::winapi::WCHAR_ path_hldr[MAX_PATH];
-            boost::detail::winapi::LPWSTR_ path = path_hldr;
-            boost::detail::winapi::get_module_file_name(NULL, path, MAX_PATH);
+            boost::winapi::WCHAR_ path_hldr[MAX_PATH];
+            boost::winapi::LPWSTR_ path = path_hldr;
+            boost::winapi::get_module_file_name(NULL, path, MAX_PATH);
             ec = last_error_code();
     
             // In case of ERROR_INSUFFICIENT_BUFFER_ trying to get buffer big enough to store the whole path
             for (unsigned i = 2; i < 129 && ec.value() == ERROR_INSUFFICIENT_BUFFER; i *= 2) {
                 path = new WCHAR[MAX_PATH * i];
     
-                boost::detail::winapi::get_module_file_name(NULL, path, MAX_PATH * i);
+                boost::winapi::get_module_file_name(NULL, path, MAX_PATH * i);
                 ec = last_error_code();
     
                 if (ec) {

--- a/include/boost/application/detail/windows/process_id_impl.hpp
+++ b/include/boost/application/detail/windows/process_id_impl.hpp
@@ -11,8 +11,8 @@
 #include <boost/application/detail/csbl.hpp>
 #include <boost/application/system_error.hpp>
 
-#include <boost/detail/winapi/basic_types.hpp>
-#include <boost/detail/winapi/process.hpp>
+#include <boost/winapi/basic_types.hpp>
+#include <boost/winapi/process.hpp>
 
 #ifdef BOOST_HAS_PRAGMA_ONCE
 # pragma once
@@ -23,7 +23,7 @@ namespace boost { namespace application { namespace detail {
    class  process_id_impl {
       
    public:
-      typedef boost::detail::winapi::DWORD_ native_pid_t;
+      typedef boost::winapi::DWORD_ native_pid_t;
       
       process_id_impl()
          : pid_ (0)  
@@ -37,7 +37,7 @@ namespace boost { namespace application { namespace detail {
          if(pid_)
             return pid_;
             
-         pid_ = boost::detail::winapi::GetCurrentProcessId();
+         pid_ = boost::winapi::GetCurrentProcessId();
          return pid_;
       }
         

--- a/include/boost/application/signal_binder.hpp
+++ b/include/boost/application/signal_binder.hpp
@@ -22,7 +22,7 @@
 #include <boost/application/context.hpp>
 #include <boost/application/handler.hpp>
 
-// #include <boost/bind.hpp>
+// #include <boost/bind/bind.hpp>
 // #include <boost/thread/thread.hpp>
 
 #include <boost/application/aspects/termination_handler.hpp>


### PR DESCRIPTION
I recently downloaded boost 1.74.0 and found that some changes were needed for the bind and winapi modules to compile. This might not be a comprehensive update, but it was sufficient for my project to compile again. I hope it helps someone who runs into similar issues.